### PR TITLE
try again

### DIFF
--- a/photoz-dr8/photoz-dr8.tex
+++ b/photoz-dr8/photoz-dr8.tex
@@ -13,6 +13,7 @@
 \newcommand{\rmin}{15.0}
 \newcommand{\rmax}{21.8}
 \newcommand{\pofz}{$P(z$)}
+\newcommand{\pofzw}{$P(z)_w$\ }
 \newcommand{\Nofz}{$N(z$)}
 \newcommand{\nwei}{N(z)_{\rm wei}}
 \newcommand{\npz}{N(z)_{\rm p(z)}}
@@ -48,7 +49,7 @@ calculated for a set of training galaxies with known redshifts such that their
 density distribution in five dimensional color-magnitude space is proportional
 to that of the photometry-only sample, producing a nearly fair sample in that
 space.  The \Nofz\ of the photometric sample is then estimated by constructing
-a weighted histogram of the training set redshifts.  We also used this same
+a weighted histogram of the training set redshifts.  We use this same
 method to derive redshift probability distributions \pofz\ for individual
 galaxies.
 %\textcolor{blue}{  The \pofz\ summed over all galaxies is similar but not
@@ -83,7 +84,9 @@ galaxy yields better estimates of the overall redshift distribution, $N(z)$,
 and can decrease biases in cosmological analysis.  We note that several public
 \photoz\ codes exist that can output a \pofz\ per galaxy, e.g.  {\it Le Phare}
 \citep{arn99,ilb06}, {\it ZEBRA} \citep{fel06}, {\it BPZ} \citep{coe06}, {\it
-ArborZ} \citep{ger10}, and our own nameless method \citep{CunhaPhotoz09}.
+ArborZ} \citep{ger10}, and our own method \citep{CunhaPhotoz09}, henceforth 
+referred to as PROB-WTS.
+We use \pofzw when referring to the \pofz\  derived from PROB-WTS.  .
 
 
 In this paper, we describe a \pofz\ catalog for objects detected in the Data
@@ -226,17 +229,17 @@ Note the calibrations used for these data are derived using the ``ubercalibratio
 technique presented in \citet{Nikhil08}.  
 \section{Photometric Quantities} \label{sec:photo}
 
-In this section we describe the photometric quantities used in creation of the
+In this section we describe the photometric quantities used in the creation of the
 input catalog.  Most of these quantities are measured by the SDSS photometric
 pipeline \photo. An early version of the pipeline is described in
 \citet{LuptonADASS01}.  Other details can be found in the SDSS Data Release
 papers, e.g. \citet{dr4} and at the SDSS III website\footnote{\sdssweb}.  We
-will give a few additional details below.  Note, in comparison to DR7, the DR8
+\sout{will} give a few additional details below.  In comparison to DR7, the DR8
 makes use of an updated version of the \photo\ software reduction pipeline,
 v5\_6 rather than v5\_4, including some updates to sky subtraction that can
 change galaxy photometry and, potentially, the $P(z)$.
 
-For colors we use the SDSS ``model magnitudes'', which we will refer to as
+For colors we use the SDSS ``model magnitudes'', which we \sout{will} refer to as
 \modelmag \footnote{\DRatemags}.  Each object is fit to an elliptical
 exponential disk and an elliptical \devauc\ profile convolved with a double
 Gaussian approximation to the PSF model interpolated to the location of the
@@ -247,7 +250,7 @@ effective aperture is the same for all bands, which is appropriate for
 extraction of color information.
 
 We use ``composite model magnitudes'' as an approximate total magnitude for
-each object, which we will refer to as \cmodelmag.  For each bandpass
+each object, which we \sout{will} refer to as \cmodelmag.  For each bandpass
 separately, the flux from the best-fitting exponential and \devauc\ models are
 combined:
 \begin{equation}
@@ -397,7 +400,7 @@ http://www.oamp.fr/people/tresse/cfrs/cfrs.html} with \texttt{Class} $\geq 3$.
 \citep[DEEP2;][]{weiner05}\footnote{\tt http://deep.berkeley.edu/DR3}
 with \texttt{zqual} $\geq 3$. 
 Of these, 1,499 are an approximately magnitude-limited sample from the Extended Groth Strip (EGS).
-The remainder is $BRI$ color-selected to target $z>0.7$ galaxies, hereafter called the non-EGS sample. 
+The remainder is $BRI$ color-selected to target $z>0.7$ galaxies, hereafter denoted the non-EGS sample. 
 
     \item 197 from the Team Keck Redshift Survey \cite[TKRS;][]{wirth04}\footnote{\tt http://tkserver.keck.hawaii.edu/tksurvey/}.
 
@@ -641,7 +644,7 @@ the weights, hence the error bars should be used only for a reasonable
 reference.  A more detailed estimation of the errors would require SDSS-specific
 photometry+$N$-body simulations.  Relative to the error bars in the
 training set, the error bars in the weighted N(z) should be (very roughly)
-about 20-30\% smaller, with increased anti-correlations between neighboring
+about 10-30\% smaller, with increased anti-correlations between neighboring
 bins, but to be certain would require more detailed investigation.
 %There are also 
 We explore these issues in more detail for a different data set
@@ -934,9 +937,9 @@ criteria.
 \begin{figure} [h]\centering
     \includegraphics[scale=0.5]{figures/pz.egs.c3n7.paper.ps}
 
-    \caption{ Proof of concept analysis of errors in a fictitious lensing
+    \caption{ Proof-of-concept analysis of errors in a fictitious lensing
     analysis.  For this example we used only DEEP2-EGS galaxies but perfect
-    weights estimate; the sample variance, and width of individual \pofz, are
+    weights estimate; the sample variance and width of individual \pofz are
     much larger than for the DR8 analysis.  {\em Top:} Lensing signal
     calibration bias (Eq.  \ref{eq:lensbias}) as a function of lens redshift,
     for four  cases labeled on the plot and discussed in the text.  {\em


### PR DESCRIPTION
In the github website, I see that my changes came through. I paste what I'm getting below (search for + and - signs):

photoz-dr8/photoz-dr8.tex View file @ 735c4e0
... ... 
@@ -13,6 +13,7 @@
13  13  
 \newcommand{\rmin}{15.0}
14  14  
 \newcommand{\rmax}{21.8}
15  15  
 \newcommand{\pofz}{$P(z$)}
    16  
+\newcommand{\pofzw}{$P(z)_w$\ }
16  17  
 \newcommand{\Nofz}{$N(z$)}
17  18  
 \newcommand{\nwei}{N(z)_{\rm wei}}
18  19  
 \newcommand{\npz}{N(z)_{\rm p(z)}}
... ... 
@@ -48,7 +49,7 @@ calculated for a set of training galaxies with known redshifts such that their
48  49  
 density distribution in five dimensional color-magnitude space is proportional
49  50  
 to that of the photometry-only sample, producing a nearly fair sample in that
50  51  
 space.  The \Nofz\ of the photometric sample is then estimated by constructing
51  
-a weighted histogram of the training set redshifts.  We also used this same
    52  
+a weighted histogram of the training set redshifts.  We use this same
52  53  
 method to derive redshift probability distributions \pofz\ for individual
53  54  
 galaxies.
54  55  
 %\textcolor{blue}{  The \pofz\ summed over all galaxies is similar but not
... ... 
@@ -83,7 +84,9 @@ galaxy yields better estimates of the overall redshift distribution, $N(z)$,
83  84  
 and can decrease biases in cosmological analysis.  We note that several public
84  85  
 \photoz\ codes exist that can output a \pofz\ per galaxy, e.g.  {\it Le Phare}
85  86  
 \citep{arn99,ilb06}, {\it ZEBRA} \citep{fel06}, {\it BPZ} \citep{coe06}, {\it
86  
-ArborZ} \citep{ger10}, and our own nameless method \citep{CunhaPhotoz09}.
    87  
+ArborZ} \citep{ger10}, and our own method \citep{CunhaPhotoz09}, henceforth 
    88  
+referred to as PROB-WTS.
    89  
+We use \pofzw when referring to the \pofz\  derived from PROB-WTS.  .
87  90  

88  91  

89  92  
 In this paper, we describe a \pofz\ catalog for objects detected in the Data
... ... 
@@ -226,17 +229,17 @@ Note the calibrations used for these data are derived using the ``ubercalibratio
226 229 
 technique presented in \citet{Nikhil08}.  
227 230 
 \section{Photometric Quantities} \label{sec:photo}
228 231 

229  
-In this section we describe the photometric quantities used in creation of the
    232 
+In this section we describe the photometric quantities used in the creation of the
230 233 
 input catalog.  Most of these quantities are measured by the SDSS photometric
231 234 
 pipeline \photo. An early version of the pipeline is described in
232 235 
 \citet{LuptonADASS01}.  Other details can be found in the SDSS Data Release
233 236 
 papers, e.g. \citet{dr4} and at the SDSS III website\footnote{\sdssweb}.  We
234  
-will give a few additional details below.  Note, in comparison to DR7, the DR8
    237 
+\sout{will} give a few additional details below.  In comparison to DR7, the DR8
235 238 
 makes use of an updated version of the \photo\ software reduction pipeline,
236 239 
 v5_6 rather than v5_4, including some updates to sky subtraction that can
237 240 
 change galaxy photometry and, potentially, the $P(z)$.
238 241 

239  
-For colors we use the SDSS `model magnitudes'', which we will refer to as
    242 
+For colors we use the SDSS`model magnitudes'', which we \sout{will} refer to as
240 243 
 \modelmag \footnote{\DRatemags}.  Each object is fit to an elliptical
241 244 
 exponential disk and an elliptical \devauc\ profile convolved with a double
242 245 
 Gaussian approximation to the PSF model interpolated to the location of the
... ... 
@@ -247,7 +250,7 @@ effective aperture is the same for all bands, which is appropriate for
247 250 
 extraction of color information.
248 251 

249 252 
 We use ``composite model magnitudes'' as an approximate total magnitude for
250  
-each object, which we will refer to as \cmodelmag.  For each bandpass
    253 
+each object, which we \sout{will} refer to as \cmodelmag.  For each bandpass
251 254 
 separately, the flux from the best-fitting exponential and \devauc\ models are
252 255 
 combined:
253 256 
 \begin{equation}
... ... 
@@ -397,7 +400,7 @@ http://www.oamp.fr/people/tresse/cfrs/cfrs.html} with \texttt{Class} $\geq 3$.
397 400 
 \citep[DEEP2;][]{weiner05}\footnote{\tt http://deep.berkeley.edu/DR3}
398 401 
 with \texttt{zqual} $\geq 3$. 
399 402 
 Of these, 1,499 are an approximately magnitude-limited sample from the Extended Groth Strip (EGS).
400  
-The remainder is $BRI$ color-selected to target $z>0.7$ galaxies, hereafter called the non-EGS sample. 
    403 
+The remainder is $BRI$ color-selected to target $z>0.7$ galaxies, hereafter denoted the non-EGS sample. 
401 404 

402 405 
     \item 197 from the Team Keck Redshift Survey \cite[TKRS;][]{wirth04}\footnote{\tt http://tkserver.keck.hawaii.edu/tksurvey/}.
403 406 

... ... 
@@ -641,7 +644,7 @@ the weights, hence the error bars should be used only for a reasonable
641 644 
 reference.  A more detailed estimation of the errors would require SDSS-specific
642 645 
 photometry+$N$-body simulations.  Relative to the error bars in the
643 646 
 training set, the error bars in the weighted N(z) should be (very roughly)
644  
-about 20-30\% smaller, with increased anti-correlations between neighboring
    647 
+about 10-30\% smaller, with increased anti-correlations between neighboring
645 648 
 bins, but to be certain would require more detailed investigation.
646 649 
 %There are also 
647 650 
 We explore these issues in more detail for a different data set
... ... 
@@ -934,9 +937,9 @@ criteria.
934 937 
 \begin{figure} [h]\centering
935 938 
     \includegraphics[scale=0.5]{figures/pz.egs.c3n7.paper.ps}
936 939 

937     
-    \caption{ Proof of concept analysis of errors in a fictitious lensing
  940 
-    \caption{ Proof-of-concept analysis of errors in a fictitious lensing
  938 941 
   analysis.  For this example we used only DEEP2-EGS galaxies but perfect
  939  
-    weights estimate; the sample variance, and width of individual \pofz, are
  942 
-    weights estimate; the sample variance and width of individual \pofz are
  940 943 
   much larger than for the DR8 analysis.  {\em Top:} Lensing signal
  941 944 
   calibration bias (Eq.  \ref{eq:lensbias}) as a function of lens redshift,
  942 945 
   for four  cases labeled on the plot and discussed in the text.  {\em
